### PR TITLE
Creating fix for dynamic reconfigure bug

### DIFF
--- a/lsd_slam_core/cfg/LSDDebugParams.cfg
+++ b/lsd_slam_core/cfg/LSDDebugParams.cfg
@@ -4,7 +4,7 @@ PACKAGE='lsd_slam_core'
 import roslib; roslib.load_manifest(PACKAGE)
 
 #from driver_base.msg import SensorLevels
-from dynamic_reconfigure.parameter_generator import *
+from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 

--- a/lsd_slam_core/cfg/LSDParams.cfg
+++ b/lsd_slam_core/cfg/LSDParams.cfg
@@ -4,7 +4,7 @@ PACKAGE='lsd_slam_core'
 import roslib; roslib.load_manifest(PACKAGE)
 
 #from driver_base.msg import SensorLevels
-from dynamic_reconfigure.parameter_generator import *
+from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 

--- a/lsd_slam_viewer/cfg/LSDSLAMViewerParams.cfg
+++ b/lsd_slam_viewer/cfg/LSDSLAMViewerParams.cfg
@@ -5,7 +5,7 @@ import roslib
 roslib.load_manifest(PACKAGE)
 
 #from driver_base.msg import SensorLevels
-from dynamic_reconfigure.parameter_generator import *
+from dynamic_reconfigure.parameter_generator_catkin import *
 
 gen = ParameterGenerator()
 


### PR DESCRIPTION
In catkin build system the correct command in the python dynamic reconfigure script should be:
"from dynamic_reconfigure.parameter_generator_**catkin** import *"