### PR TITLE
RGB Pointcloud and Live Camera Tracking on Pointcloud Viewer

### DIFF
--- a/lsd_slam_core/CMakeLists.txt
+++ b/lsd_slam_core/CMakeLists.txt
@@ -111,11 +111,11 @@ target_link_libraries(live_slam lsdslam ${catkin_LIBRARIES} ${G2O_LIBRARIES})
 
 
 # build image node
-add_executable(dataset src/main_on_images.cpp)
+add_executable(dataset_slam src/main_on_images.cpp)
 add_dependencies(lsdslam lsd_slam_viewer_generate_messages_cpp)
 add_dependencies(live_slam lsd_slam_viewer_generate_messages_cpp)
-add_dependencies(dataset lsd_slam_viewer_generate_messages_cpp)
-target_link_libraries(dataset lsdslam ${catkin_LIBRARIES} ${G2O_LIBRARIES})
+add_dependencies(dataset_slam lsd_slam_viewer_generate_messages_cpp)
+target_link_libraries(dataset_slam lsdslam ${catkin_LIBRARIES} ${G2O_LIBRARIES})
 target_link_libraries(live_slam lsdslam ${OpenCV_LIBRARIES})
 
 # TODO add INSTALL

--- a/lsd_slam_core/cfg/LSDParams.cfg
+++ b/lsd_slam_core/cfg/LSDParams.cfg
@@ -33,8 +33,9 @@ gen.add("relocalizationTH", double_t, 0, "How good a relocalization-attempt has 
 
 gen.add("depthSmoothingFactor", double_t, 0, "How much to smooth the depth map. Larger -> Less Smoothing", 1, 0, 10)
 
+gen.add("fullResetRequested", bool_t, 0, "Reset the LSD SLAM system.", True)
+
 
 
 
 exit(gen.generate(PACKAGE, "Config", "LSDParams"))
-

--- a/lsd_slam_core/src/DataStructures/Frame.cpp
+++ b/lsd_slam_core/src/DataStructures/Frame.cpp
@@ -1,8 +1,9 @@
+
 /**
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -28,14 +29,35 @@ namespace lsd_slam
 
 int privateFrameAllocCount = 0;
 
-
+Frame::Frame(int id, int width, int height, const Eigen::Matrix3f& K, double timestamp, const unsigned char* image,  const unsigned char* rgbImage)
+{
+	initialize(id, width, height, K, timestamp);
+ 	data.image[0] = FrameMemory::getInstance().getFloatBuffer(data.width[0]*data.height[0]);
+	data.imageRGB[0] = FrameMemory::getInstance().getFloatBuffer(data.width[0]*data.height[0]*3);
+ 	float* maxPt = data.image[0] + data.width[0]*data.height[0];
+	float* maxPtRGB = data.imageRGB[0] + data.width[0]*data.height[0]*3;
+ 	for(float* pt = data.image[0]; pt < maxPt; pt++)
+	{
+		*pt = *image;
+		image++;
+	}
+	for(float* pt = data.imageRGB[0]; pt < maxPtRGB; pt++)
+	{
+		*pt = *rgbImage;
+		rgbImage++;
+	}
+ 	data.imageValid[0] = true;
+ 	privateFrameAllocCount++;
+ 	if(enablePrintDebugInfo && printMemoryDebugInfo)
+		printf("ALLOCATED frame %d, now there are %d\n", this->id(), privateFrameAllocCount);
+ }
 
 
 
 Frame::Frame(int id, int width, int height, const Eigen::Matrix3f& K, double timestamp, const unsigned char* image)
 {
 	initialize(id, width, height, K, timestamp);
-	
+
 	data.image[0] = FrameMemory::getInstance().getFloatBuffer(data.width[0]*data.height[0]);
 	float* maxPt = data.image[0] + data.width[0]*data.height[0];
 
@@ -56,7 +78,7 @@ Frame::Frame(int id, int width, int height, const Eigen::Matrix3f& K, double tim
 Frame::Frame(int id, int width, int height, const Eigen::Matrix3f& K, double timestamp, const float* image)
 {
 	initialize(id, width, height, K, timestamp);
-	
+
 	data.image[0] = FrameMemory::getInstance().getFloatBuffer(data.width[0]*data.height[0]);
 	memcpy(data.image[0], image, data.width[0]*data.height[0] * sizeof(float));
 	data.imageValid[0] = true;
@@ -83,6 +105,7 @@ Frame::~Frame()
 	for (int level = 0; level < PYRAMID_LEVELS; ++ level)
 	{
 		FrameMemory::getInstance().returnBuffer(data.image[level]);
+		FrameMemory::getInstance().returnBuffer(data.imageRGB[level]);
 		FrameMemory::getInstance().returnBuffer(reinterpret_cast<float*>(data.gradients[level]));
 		FrameMemory::getInstance().returnBuffer(data.maxGradients[level]);
 		FrameMemory::getInstance().returnBuffer(data.idepth[level]);
@@ -210,7 +233,7 @@ void Frame::setDepth(const DepthMapPixelHypothesis* newDepth)
 	float* pyrIDepth = data.idepth[0];
 	float* pyrIDepthVar = data.idepthVar[0];
 	float* pyrIDepthMax = pyrIDepth + (data.width[0]*data.height[0]);
-	
+
 	float sumIdepth=0;
 	int numIdepth=0;
 
@@ -230,7 +253,7 @@ void Frame::setDepth(const DepthMapPixelHypothesis* newDepth)
 			*pyrIDepthVar = -1;
 		}
 	}
-	
+
 	meanIdepth = sumIdepth / numIdepth;
 	numPoints = numIdepth;
 
@@ -283,7 +306,7 @@ void Frame::setDepthFromGroundTruth(const float* depth, float cov_scale)
 			++ pyrIDepthVar;
 		}
 	}
-	
+
 	data.idepthValid[0] = true;
 	data.idepthVarValid[0] = true;
 // 	data.refIDValid[0] = true;
@@ -397,7 +420,7 @@ bool Frame::minimizeInMemory()
 void Frame::initialize(int id, int width, int height, const Eigen::Matrix3f& K, double timestamp)
 {
 	data.id = id;
-	
+
 	pose = new FramePoseStruct(this);
 
 	data.K[0] = K;
@@ -405,21 +428,21 @@ void Frame::initialize(int id, int width, int height, const Eigen::Matrix3f& K, 
 	data.fy[0] = K(1,1);
 	data.cx[0] = K(0,2);
 	data.cy[0] = K(1,2);
-	
+
 	data.KInv[0] = K.inverse();
 	data.fxInv[0] = data.KInv[0](0,0);
 	data.fyInv[0] = data.KInv[0](1,1);
 	data.cxInv[0] = data.KInv[0](0,2);
 	data.cyInv[0] = data.KInv[0](1,2);
-	
+
 	data.timestamp = timestamp;
 
 	data.hasIDepthBeenSet = false;
 	depthHasBeenUpdatedFlag = false;
-	
+
 	referenceID = -1;
 	referenceLevel = -1;
-	
+
 	numMappablePixels = -1;
 
 	for (int level = 0; level < PYRAMID_LEVELS; ++ level)
@@ -434,6 +457,7 @@ void Frame::initialize(int id, int width, int height, const Eigen::Matrix3f& K, 
 		data.idepthVarValid[level] = false;
 
 		data.image[level] = 0;
+		data.imageRGB[level] = 0;
 		data.gradients[level] = 0;
 		data.maxGradients[level] = 0;
 		data.idepth[level] = 0;
@@ -441,7 +465,7 @@ void Frame::initialize(int id, int width, int height, const Eigen::Matrix3f& K, 
 		data.reActivationDataValid = false;
 
 // 		data.refIDValid[level] = false;
-		
+
 		if (level > 0)
 		{
 			data.fx[level] = data.fx[level-1] * 0.5;
@@ -495,7 +519,7 @@ void Frame::buildImage(int level)
 		printf("Frame::buildImage(0): Loading image from disk is not implemented yet! No-op.\n");
 		return;
 	}
-	
+
 	require(IMAGE, level - 1);
 	boost::unique_lock<boost::mutex> lock2(buildMutex);
 
@@ -562,36 +586,36 @@ void Frame::buildImage(int level)
 		int height_iteration_count = height / 2;
 		const float* cur_px = source;
 		const float* next_row_px = source + width;
-		
+
 		__asm__ __volatile__
 		(
 			"vldmia %[p025], {q10}                        \n\t" // p025(q10)
-			
+
 			".height_loop:                                \n\t"
-			
+
 				"mov r5, %[width_iteration_count]             \n\t" // store width_iteration_count
 				".width_loop:                                 \n\t"
-				
+
 					"vldmia   %[cur_px]!, {q0-q1}             \n\t" // top_left(q0), top_right(q1)
 					"vldmia   %[next_row_px]!, {q2-q3}        \n\t" // bottom_left(q2), bottom_right(q3)
-		
+
 					"vadd.f32 q0, q0, q2                      \n\t" // left(q0)
 					"vadd.f32 q1, q1, q3                      \n\t" // right(q1)
-		
+
 					"vpadd.f32 d0, d0, d1                     \n\t" // pairwise add into sum(q0)
 					"vpadd.f32 d1, d2, d3                     \n\t"
 					"vmul.f32 q0, q0, q10                     \n\t" // multiply with 0.25 to get average
-					
+
 					"vstmia %[dest]!, {q0}                    \n\t"
-				
+
 				"subs     %[width_iteration_count], %[width_iteration_count], #1 \n\t"
 				"bne      .width_loop                     \n\t"
 				"mov      %[width_iteration_count], r5    \n\t" // restore width_iteration_count
-				
+
 				// Advance one more line
 				"add      %[cur_px], %[cur_px], %[rowSize]    \n\t"
 				"add      %[next_row_px], %[next_row_px], %[rowSize] \n\t"
-			
+
 			"subs     %[height_iteration_count], %[height_iteration_count], #1 \n\t"
 			"bne      .height_loop                       \n\t"
 
@@ -638,6 +662,11 @@ void Frame::releaseImage(int level)
 	}
 	FrameMemory::getInstance().returnBuffer(data.image[level]);
 	data.image[level] = 0;
+	/* check using imageRGB and release */
+	if(data.image[level] != 0){
+		FrameMemory::getInstance().returnBuffer(data.imageRGB[level]);
+		data.imageRGB[level] = 0;
+	}
 }
 
 void Frame::buildGradients(int level)
@@ -658,7 +687,7 @@ void Frame::buildGradients(int level)
 	const float* img_pt = data.image[level] + width;
 	const float* img_pt_max = data.image[level] + width*(height-1);
 	Eigen::Vector4f* gradxyii_pt = data.gradients[level] + width;
-	
+
 	// in each iteration i need -1,0,p1,mw,pw
 	float val_m1 = *(img_pt-1);
 	float val_00 = *img_pt;
@@ -701,7 +730,7 @@ void Frame::buildMaxGradients(int level)
 	int height = data.height[level];
 	if (data.maxGradients[level] == 0)
 		data.maxGradients[level] = FrameMemory::getInstance().getFloatBuffer(width * height);
-	
+
 	float* maxGradTemp = FrameMemory::getInstance().getFloatBuffer(width * height);
 
 
@@ -787,16 +816,16 @@ void Frame::buildIDepthAndIDepthVar(int level)
 
 	require(IDEPTH, level - 1);
 	boost::unique_lock<boost::mutex> lock2(buildMutex);
-	
+
 	if(data.idepthValid[level] && data.idepthVarValid[level])
 		return;
 
 	if(enablePrintDebugInfo && printFrameBuildDebugInfo)
 		printf("CREATE IDepth lvl %d for frame %d\n", level, id());
-	
+
 	int width = data.width[level];
 	int height = data.height[level];
-	
+
 	if (data.idepth[level] == 0)
 		data.idepth[level] = FrameMemory::getInstance().getFloatBuffer(width * height);
 	if (data.idepthVar[level] == 0)
@@ -808,7 +837,7 @@ void Frame::buildIDepthAndIDepthVar(int level)
 	const float* idepthVarSource = data.idepthVar[level - 1];
 	float* idepthDest = data.idepth[level];
 	float* idepthVarDest = data.idepthVar[level];
-	
+
 	for(int y=0;y<height;y++)
 	{
 		for(int x=0;x<width;x++)
@@ -857,7 +886,7 @@ void Frame::buildIDepthAndIDepthVar(int level)
 				idepthSumsSum += ivar * idepthSource[idx+sw+1];
 				num++;
 			}
-			
+
 			if(num > 0)
 			{
 				float depth = ivarSumsSum / idepthSumsSum;
@@ -883,7 +912,7 @@ void Frame::releaseIDepth(int level)
 		printf("Frame::releaseIDepth(0): Storing depth on disk is not supported yet! No-op.\n");
 		return;
 	}
-	
+
 	FrameMemory::getInstance().returnBuffer(data.idepth[level]);
 	data.idepth[level] = 0;
 }

--- a/lsd_slam_core/src/DataStructures/Frame.h
+++ b/lsd_slam_core/src/DataStructures/Frame.h
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -46,35 +46,36 @@ public:
 
 
 	Frame(int id, int width, int height, const Eigen::Matrix3f& K, double timestamp, const unsigned char* image);
+	Frame(int id, int width, int height, const Eigen::Matrix3f& K, double timestamp, const unsigned char* image, const unsigned char* rgbImage);
 
 	Frame(int id, int width, int height, const Eigen::Matrix3f& K, double timestamp, const float* image);
 
 	~Frame();
-	
-	
+
+
 	/** Sets or updates idepth and idepthVar on level zero. Invalidates higher levels. */
 	void setDepth(const DepthMapPixelHypothesis* newDepth);
 
 	/** Calculates mean information for statistical purposes. */
 	void calculateMeanInformation();
-	
+
 	/** Sets ground truth depth (real, not inverse!) from a float array on level zero. Invalidates higher levels. */
 	void setDepthFromGroundTruth(const float* depth, float cov_scale = 1.0f);
-	
+
 	/** Prepares this frame for stereo comparisons with the other frame (computes some intermediate values that will be needed) */
 	void prepareForStereoWith(Frame* other, Sim3 thisToOther, const Eigen::Matrix3f& K, const int level);
 
-	
+
 
 	// Accessors
 	/** Returns the unique frame id. */
 	inline int id() const;
-	
+
 	/** Returns the frame's image width. */
 	inline int width(int level = 0) const;
 	/** Returns the frame's image height. */
 	inline int height(int level = 0) const;
-	
+
 	/** Returns the frame's intrinsics matrix. */
 	inline const Eigen::Matrix3f& K(int level = 0) const;
 	/** Returns the frame's inverse intrinsics matrix. */
@@ -95,11 +96,12 @@ public:
 	inline float cxInv(int level = 0) const;
 	/** Returns KInv(1, 2). */
 	inline float cyInv(int level = 0) const;
-	
+
 	/** Returns the frame's recording timestamp. */
 	inline double timestamp() const;
-	
+
 	inline float* image(int level = 0);
+	inline float* imageRGB(int level = 0);
 	inline const Eigen::Vector4f* gradients(int level = 0);
 	inline const float* maxGradients(int level = 0);
 	inline bool hasIDepthBeenSet() const;
@@ -123,10 +125,10 @@ public:
 		IDEPTH			= 1<<3,
 		IDEPTH_VAR		= 1<<4,
 		REF_ID			= 1<<5,
-		
+
 		ALL = IMAGE | GRADIENTS | MAX_GRADIENTS | IDEPTH | IDEPTH_VAR | REF_ID
 	};
-	
+
 
 	void setPermaRef(TrackingReference* reference);
 	void takeReActivationData(DepthMapPixelHypothesis* depthMap);
@@ -212,44 +214,45 @@ private:
 
 	void initialize(int id, int width, int height, const Eigen::Matrix3f& K, double timestamp);
 	void setDepth_Allocate();
-	
+
 	void buildImage(int level);
 	void releaseImage(int level);
-	
+
 	void buildGradients(int level);
 	void releaseGradients(int level);
-	
+
 	void buildMaxGradients(int level);
 	void releaseMaxGradients(int level);
-	
+
 	void buildIDepthAndIDepthVar(int level);
 	void releaseIDepth(int level);
 	void releaseIDepthVar(int level);
-	
+
 	void printfAssert(const char* message) const;
-	
+
 	struct Data
 	{
 		int id;
-		
+
 		int width[PYRAMID_LEVELS], height[PYRAMID_LEVELS];
 
 		Eigen::Matrix3f K[PYRAMID_LEVELS], KInv[PYRAMID_LEVELS];
 		float fx[PYRAMID_LEVELS], fy[PYRAMID_LEVELS], cx[PYRAMID_LEVELS], cy[PYRAMID_LEVELS];
 		float fxInv[PYRAMID_LEVELS], fyInv[PYRAMID_LEVELS], cxInv[PYRAMID_LEVELS], cyInv[PYRAMID_LEVELS];
-		
+
 		double timestamp;
 
-		
+
 		float* image[PYRAMID_LEVELS];
+		float* imageRGB[PYRAMID_LEVELS];
 		bool imageValid[PYRAMID_LEVELS];
-		
+
 		Eigen::Vector4f* gradients[PYRAMID_LEVELS];
 		bool gradientsValid[PYRAMID_LEVELS];
-		
+
 		float* maxGradients[PYRAMID_LEVELS];
 		bool maxGradientsValid[PYRAMID_LEVELS];
-		
+
 
 		bool hasIDepthBeenSet;
 
@@ -257,7 +260,7 @@ private:
 		// a pixel is valid iff idepthVar[i] > 0.
 		float* idepth[PYRAMID_LEVELS];
 		bool idepthValid[PYRAMID_LEVELS];
-		
+
 		// MUST contain -1 for invalid pixel (that dont have depth)!!
 		float* idepthVar[PYRAMID_LEVELS];
 		bool idepthVarValid[PYRAMID_LEVELS];
@@ -359,6 +362,10 @@ inline float* Frame::image(int level)
 	if (! data.imageValid[level])
 		require(IMAGE, level);
 	return data.image[level];
+}
+inline float* Frame::imageRGB(int level)
+{
+	return data.imageRGB[level];
 }
 inline const Eigen::Vector4f* Frame::gradients(int level)
 {

--- a/lsd_slam_core/src/IOWrapper/OpenCV/ImageDisplay_OpenCV.cpp
+++ b/lsd_slam_core/src/IOWrapper/OpenCV/ImageDisplay_OpenCV.cpp
@@ -116,13 +116,15 @@ void displayImage(const char* windowName, const cv::Mat& image, bool autoSize)
 
 int waitKey(int milliseconds)
 {
-	return cv::waitKey(milliseconds);
+	//return cv::waitKey(milliseconds);
+        return 1;
 }
 
 int waitKeyNoConsume(int milliseconds)
 {
 	// Cannot implement this with OpenCV functions.
-	return cv::waitKey(milliseconds);
+	//return cv::waitKey(milliseconds);
+        return 1;
 }
 
 void closeAllWindows()

--- a/lsd_slam_core/src/IOWrapper/OpenCV/ImageDisplay_OpenCV.cpp
+++ b/lsd_slam_core/src/IOWrapper/OpenCV/ImageDisplay_OpenCV.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -116,15 +116,15 @@ void displayImage(const char* windowName, const cv::Mat& image, bool autoSize)
 
 int waitKey(int milliseconds)
 {
-	//return cv::waitKey(milliseconds);
-        return 1;
+	return cv::waitKey(milliseconds);
+  //      return 1;
 }
 
 int waitKeyNoConsume(int milliseconds)
 {
 	// Cannot implement this with OpenCV functions.
-	//return cv::waitKey(milliseconds);
-        return 1;
+	return cv::waitKey(milliseconds);
+        //return 1;
 }
 
 void closeAllWindows()

--- a/lsd_slam_core/src/IOWrapper/OpenCV/ImageDisplay_OpenCV.cpp
+++ b/lsd_slam_core/src/IOWrapper/OpenCV/ImageDisplay_OpenCV.cpp
@@ -117,14 +117,12 @@ void displayImage(const char* windowName, const cv::Mat& image, bool autoSize)
 int waitKey(int milliseconds)
 {
 	return cv::waitKey(milliseconds);
-  //      return 1;
 }
 
 int waitKeyNoConsume(int milliseconds)
 {
 	// Cannot implement this with OpenCV functions.
 	return cv::waitKey(milliseconds);
-        //return 1;
 }
 
 void closeAllWindows()

--- a/lsd_slam_core/src/IOWrapper/ROS/ROSImageStreamThread.cpp
+++ b/lsd_slam_core/src/IOWrapper/ROS/ROSImageStreamThread.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -114,7 +114,7 @@ void ROSImageStreamThread::vidCb(const sensor_msgs::ImageConstPtr img)
 {
 	if(!haveCalib) return;
 
-	cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(img, sensor_msgs::image_encodings::MONO8);
+	cv_bridge::CvImagePtr cv_ptr = cv_bridge::toCvCopy(img, sensor_msgs::image_encodings::RGB8);
 
 	if(img->header.seq < (unsigned int)lastSEQ)
 	{

--- a/lsd_slam_core/src/IOWrapper/ROS/ROSOutput3DWrapper.cpp
+++ b/lsd_slam_core/src/IOWrapper/ROS/ROSOutput3DWrapper.cpp
@@ -99,19 +99,7 @@ void ROSOutput3DWrapper::publishKeyframe(Frame* f)
 
 	const float* idepth = f->idepth(publishLvl);
 	const float* idepthVar = f->idepthVar(publishLvl);
-	//const float* color = f->image(publishLvl);
 	const float* color = f->imageRGB(publishLvl);
-  /*
-	for(int idx=0;idx < w*h; idx++)
-	{
-		pc[idx].idepth = idepth[idx];
-		pc[idx].idepth_var = idepthVar[idx];
-		pc[idx].color[0] = color[idx];
-		pc[idx].color[1] = color[idx];
-		pc[idx].color[2] = color[idx];
-		pc[idx].color[3] = color[idx];
-	}
-	*/
 
 	for(int idx=0,idxRGB=0;idx < w*h; idx++,idxRGB+=3)
 	{
@@ -198,7 +186,6 @@ void ROSOutput3DWrapper::publishTrackedFrame(Frame* kf)
 
 	pMsg.header.stamp = ros::Time(kf->timestamp());
 	pMsg.header.frame_id = "world";
-        //pMsg.header.frame_id = std::to_string(kf->id());
 	pose_publisher.publish(pMsg);
 }
 

--- a/lsd_slam_core/src/IOWrapper/ROS/ROSOutput3DWrapper.h
+++ b/lsd_slam_core/src/IOWrapper/ROS/ROSOutput3DWrapper.h
@@ -99,6 +99,9 @@ private:
 	std::string pose_channel;
 	ros::Publisher pose_publisher;
 
+	std::string key_pose_channel;
+	ros::Publisher key_pose_publisher;
+
 	ros::NodeHandle nh_;
 };
 }

--- a/lsd_slam_core/src/IOWrapper/ROS/rosReconfigure.h
+++ b/lsd_slam_core/src/IOWrapper/ROS/rosReconfigure.h
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -99,6 +99,8 @@ void dynConfCb(lsd_slam_core::LSDParamsConfig &config, uint32_t level)
 	maxLoopClosureCandidates = config.maxLoopClosureCandidates;
 	loopclosureStrictness = config.loopclosureStrictness;
 	relocalizationTH = config.relocalizationTH;
+
+	fullResetRequested = config.fullResetRequested;
 }
 
 }

--- a/lsd_slam_core/src/LiveSLAMWrapper.cpp
+++ b/lsd_slam_core/src/LiveSLAMWrapper.cpp
@@ -121,7 +121,6 @@ void LiveSLAMWrapper::newImageCallback(const cv::Mat& img, Timestamp imgTime)
 	else
 		cvtColor(img, grayImg, CV_RGB2GRAY);
 
-
 	// Assert that we work with 8 bit images
 	assert(grayImg.elemSize() == 1);
 	assert(fx != 0 || fy != 0);

--- a/lsd_slam_core/src/LiveSLAMWrapper.cpp
+++ b/lsd_slam_core/src/LiveSLAMWrapper.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -89,19 +89,20 @@ void LiveSLAMWrapper::Loop()
 			notifyCondition.wait(waitLock);
 		}
 		waitLock.unlock();
-		
-		
+
+
 		if(fullResetRequested)
 		{
 			resetAll();
 			fullResetRequested = false;
 			if (!(imageStream->getBuffer()->size() > 0))
 				continue;
+			printf("LiveSLAMWrapper. Full system reset\n");
 		}
-		
+
 		TimestampedMat image = imageStream->getBuffer()->first();
 		imageStream->getBuffer()->popFront();
-		
+
 		// process image
 		//Util::displayImage("MyVideo", image.data);
 		newImageCallback(image.data, image.timestamp);
@@ -119,7 +120,7 @@ void LiveSLAMWrapper::newImageCallback(const cv::Mat& img, Timestamp imgTime)
 		grayImg = img;
 	else
 		cvtColor(img, grayImg, CV_RGB2GRAY);
-	
+
 
 	// Assert that we work with 8 bit images
 	assert(grayImg.elemSize() == 1);
@@ -129,12 +130,12 @@ void LiveSLAMWrapper::newImageCallback(const cv::Mat& img, Timestamp imgTime)
 	// need to initialize
 	if(!isInitialized)
 	{
-		monoOdometry->randomInit(grayImg.data, imgTime.toSec(), 1);
+		monoOdometry->randomInit(grayImg.data, img.data, imgTime.toSec(), 1);
 		isInitialized = true;
 	}
 	else if(isInitialized && monoOdometry != nullptr)
 	{
-		monoOdometry->trackFrame(grayImg.data,imageSeqNumber,false,imgTime.toSec());
+		monoOdometry->trackFrame(grayImg.data, img.data, imageSeqNumber,false,imgTime.toSec());
 	}
 }
 

--- a/lsd_slam_core/src/SlamSystem.cpp
+++ b/lsd_slam_core/src/SlamSystem.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -70,7 +70,7 @@ SlamSystem::SlamSystem(int w, int h, Eigen::Matrix3f K, bool enableSLAM)
 	createNewKeyFrame = false;
 
 	map =  new DepthMap(w,h,K);
-	
+
 	newConstraintAdded = false;
 	haveUnmergedOptimizationOffset = false;
 
@@ -266,7 +266,7 @@ void SlamSystem::finalize()
 void SlamSystem::constraintSearchThreadLoop()
 {
 	printf("Started  constraint search thread!\n");
-	
+
 	boost::unique_lock<boost::mutex> lock(newKeyFrameMutex);
 	int failedToRetrack = 0;
 
@@ -854,7 +854,7 @@ void SlamSystem::gtDepthInit(uchar* image, float* depth, double timeStamp, int i
 }
 
 
-void SlamSystem::randomInit(uchar* image, double timeStamp, int id)
+void SlamSystem::randomInit(uchar* image, uchar* rgbImage, double timeStamp, int id)
 {
 	printf("Doing Random initialization!\n");
 
@@ -864,7 +864,7 @@ void SlamSystem::randomInit(uchar* image, double timeStamp, int id)
 
 	currentKeyFrameMutex.lock();
 
-	currentKeyFrame.reset(new Frame(id, width, height, K, timeStamp, image));
+	currentKeyFrame.reset(new Frame(id, width, height, K, timeStamp, image, rgbImage));
 	map->initializeRandomly(currentKeyFrame.get());
 	keyFrameGraph->addFrame(currentKeyFrame.get());
 
@@ -887,10 +887,10 @@ void SlamSystem::randomInit(uchar* image, double timeStamp, int id)
 
 }
 
-void SlamSystem::trackFrame(uchar* image, unsigned int frameID, bool blockUntilMapped, double timestamp)
+void SlamSystem::trackFrame(uchar* image, uchar* rgbImage, unsigned int frameID, bool blockUntilMapped, double timestamp)
 {
 	// Create new frame
-	std::shared_ptr<Frame> trackingNewFrame(new Frame(frameID, width, height, K, timestamp, image));
+	std::shared_ptr<Frame> trackingNewFrame(new Frame(frameID, width, height, K, timestamp, image, rgbImage));
 
 	if(!trackingIsGood)
 	{
@@ -1606,7 +1606,7 @@ bool SlamSystem::optimizationIteration(int itsPerTry, float minChange)
 
 	// Do the optimization. This can take quite some time!
 	int its = keyFrameGraph->optimize(itsPerTry);
-	
+
 
 	// save the optimization result.
 	poseConsistencyMutex.lock_shared();

--- a/lsd_slam_core/src/SlamSystem.h
+++ b/lsd_slam_core/src/SlamSystem.h
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -73,16 +73,16 @@ public:
 	SlamSystem& operator=(const SlamSystem&) = delete;
 	~SlamSystem();
 
-	void randomInit(uchar* image, double timeStamp, int id);
+	void randomInit(uchar* image, uchar* rgbImage, double timeStamp, int id);
 	void gtDepthInit(uchar* image, float* depth, double timeStamp, int id);
 
-	
+
 
 	// tracks a frame.
 	// first frame will return Identity = camToWord.
 	// returns camToWord transformation of the tracked frame.
 	// frameID needs to be monotonically increasing.
-	void trackFrame(uchar* image, unsigned int frameID, bool blockUntilMapped, double timestamp);
+	void trackFrame(uchar* image, uchar* rgbImage, unsigned int frameID, bool blockUntilMapped, double timestamp);
 
 	// finalizes the system, i.e. blocks and does all remaining loop-closures etc.
 	void finalize();
@@ -103,11 +103,11 @@ public:
 	bool doMappingIteration();
 
 	int findConstraintsForNewKeyFrames(Frame* newKeyFrame, bool forceParent=true, bool useFABMAP=true, float closeCandidatesTH=1.0);
-	
+
 	bool optimizationIteration(int itsPerTry, float minChange);
-	
+
 	void publishKeyframeGraph();
-	
+
 	std::vector<FramePoseStruct*, Eigen::aligned_allocator<lsd_slam::FramePoseStruct*> > getAllPoses();
 
 
@@ -207,7 +207,7 @@ private:
 	bool keepRunning; // used only on destruction to signal threads to finish.
 
 
-	
+
 	// optimization thread
 	bool newConstraintAdded;
 	boost::mutex newConstraintMutex;
@@ -223,8 +223,8 @@ private:
 	// GUARANTEED to give the same result each call, and to be compatible to each other.
 	// locked exclusively during the pose-update by Mapping.
 	boost::shared_mutex poseConsistencyMutex;
-	
-	
+
+
 
 	bool depthMapScreenshotFlag;
 	std::string depthMapScreenshotFilename;
@@ -232,7 +232,7 @@ private:
 
 	/** Merges the current keyframe optimization offset to all working entities. */
 	void mergeOptimizationOffset();
-	
+
 
 	void mappingThreadLoop();
 
@@ -270,7 +270,7 @@ private:
 	void optimizationThreadLoop();
 
 
-	
+
 };
 
 }

--- a/lsd_slam_core/src/main_on_images.cpp
+++ b/lsd_slam_core/src/main_on_images.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -214,6 +214,8 @@ int main( int argc, char** argv )
 
 
 	cv::Mat image = cv::Mat(h,w,CV_8U);
+  cv::Mat imageRGB = cv::Mat(h,w,CV_8UC3);
+
 	int runningIDX=0;
 	float fakeTimeStamp = 0;
 
@@ -222,7 +224,7 @@ int main( int argc, char** argv )
 	for(unsigned int i=0;i<files.size();i++)
 	{
 		cv::Mat imageDist = cv::imread(files[i], CV_LOAD_IMAGE_GRAYSCALE);
-
+    cv::Mat imageDistRGB = cv::imread(files[i], CV_LOAD_IMAGE_COLOR);
 		if(imageDist.rows != h_inp || imageDist.cols != w_inp)
 		{
 			if(imageDist.rows * imageDist.cols == 0)
@@ -239,9 +241,9 @@ int main( int argc, char** argv )
 		assert(image.type() == CV_8U);
 
 		if(runningIDX == 0)
-			system->randomInit(image.data, fakeTimeStamp, runningIDX);
+			system->randomInit(image.data, imageRGB.data, fakeTimeStamp, runningIDX);
 		else
-			system->trackFrame(image.data, runningIDX ,hz == 0,fakeTimeStamp);
+			system->trackFrame(image.data, imageRGB.data, runningIDX ,hz == 0,fakeTimeStamp);
 		runningIDX++;
 		fakeTimeStamp+=0.03;
 

--- a/lsd_slam_core/src/util/settings.cpp
+++ b/lsd_slam_core/src/util/settings.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -35,7 +35,7 @@ bool autoRunWithinFrame = true;
 int debugDisplay = 0;
 
 bool onSceenInfoDisplay = true;
-bool displayDepthMap = true;
+bool displayDepthMap = false;
 bool dumpMap = false;
 bool doFullReConstraintTrack = false;
 

--- a/lsd_slam_core/src/util/settings.h
+++ b/lsd_slam_core/src/util/settings.h
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by

--- a/lsd_slam_viewer/CMakeLists.txt
+++ b/lsd_slam_viewer/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   roslib
   cmake_modules
+  image_transport
 )
 
 find_package(OpenGL REQUIRED)
@@ -57,6 +58,8 @@ set(SOURCE_FILES
   src/KeyFrameDisplay.cpp
   src/KeyFrameGraphDisplay.cpp
   src/settings.cpp
+  src/IOWrapper/ROSPCOutputWrapper.cpp
+  src/util/SophusUtil.cpp
 )
 
 set(HEADER_FILES
@@ -64,6 +67,8 @@ set(HEADER_FILES
   src/KeyFrameDisplay.h
   src/KeyFrameGraphDisplay.h
   src/settings.h
+  src/IOWrapper/ROSPCOutputWrapper.h
+  src/util/SophusUtil.cpp
 )
 
 include_directories(

--- a/lsd_slam_viewer/CMakeLists.txt
+++ b/lsd_slam_viewer/CMakeLists.txt
@@ -59,7 +59,6 @@ set(SOURCE_FILES
   src/KeyFrameGraphDisplay.cpp
   src/settings.cpp
   src/IOWrapper/ROSPCOutputWrapper.cpp
-  src/util/SophusUtil.cpp
 )
 
 set(HEADER_FILES
@@ -68,7 +67,6 @@ set(HEADER_FILES
   src/KeyFrameGraphDisplay.h
   src/settings.h
   src/IOWrapper/ROSPCOutputWrapper.h
-  src/util/SophusUtil.cpp
 )
 
 include_directories(

--- a/lsd_slam_viewer/cfg/LSDSLAMViewerParams.cfg
+++ b/lsd_slam_viewer/cfg/LSDSLAMViewerParams.cfg
@@ -30,6 +30,7 @@ gen.add("sparsifyFactor", int_t, 0, "only plot one out of #sparsifyFactor points
 gen.add("saveAllVideo", bool_t, 0, "save all rendered images... only use if you know what you are doing.", False)
 gen.add("keepInMemory", bool_t, 0, "If set to false, Pointcloud is only stored in OpenGL buffers, and not kept in RAM. This greatly reduces the required RAM for large maps, however also prohibits saving / dynamically changing sparsifyFactor and variance-thresholds.", True)
 
+gen.add("liveCameraTracking",bool_t,0,"visualize live tracking of the camera in the pointcloud display", False)
+gen.add("outputPointCloudPublisher",bool_t,0,"Allows for outputting the pointcloud to the /lsd_slam/pc_image topic.", False)
 
 exit(gen.generate(PACKAGE, "Config", "LSDSLAMViewerParams"))
-

--- a/lsd_slam_viewer/package.xml
+++ b/lsd_slam_viewer/package.xml
@@ -20,6 +20,8 @@
   <build_depend>roslib</build_depend>
   <build_depend>rosbag</build_depend>
   <build_depend>message_generation</build_depend>
+  <build_depend>image_transport</build_depend>
+
 
   <run_depend>cmake_modules</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -28,5 +30,6 @@
   <run_depend>roscpp</run_depend>
   <run_depend>roslib</run_depend>
   <run_depend>rosbag</run_depend>
+  <run_depend>image_transport</run_depend>
 
 </package>

--- a/lsd_slam_viewer/src/IOWrapper/ROSPCOutputWrapper.cpp
+++ b/lsd_slam_viewer/src/IOWrapper/ROSPCOutputWrapper.cpp
@@ -1,0 +1,49 @@
+/**
+* This file is part of LSD-SLAM.
+*
+* Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
+* For more information see <http://vision.in.tum.de/lsdslam>
+*
+* LSD-SLAM is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* LSD-SLAM is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with LSD-SLAM. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "ROSPCOutputWrapper.h"
+#include <ros/ros.h>
+
+// Publish Additional Data
+#include "image_transport/image_transport.h"
+
+#include <opencv2/opencv.hpp>
+// For sleeping.
+#include <unistd.h>
+
+ROSPCOutputWrapper::ROSPCOutputWrapper(int width, int height)
+{
+	this->width = width;
+	this->height = height;
+  image_transport::ImageTransport it(nh_);
+	//pc_image_channel_name = nh_.resolveName("lsd_slam/pc_image");
+  pc_image_publisher = it.advertise("lsd_slam/pc_image", 1);
+	//pc_image_publisher = nh_.advertise<image_transport::ImageTransport>(pc_image_channel_name,1);
+  printf("ROSPCOutputWrapper. Should be initialized.\n");
+
+}
+
+ROSPCOutputWrapper::~ROSPCOutputWrapper()
+{
+}
+void ROSPCOutputWrapper::publishPointCloudImage(cv::Mat* img_matrix){
+    msg = cv_bridge::CvImage(std_msgs::Header(), "bgr8", *img_matrix).toImageMsg();
+    pc_image_publisher.publish(msg);
+}

--- a/lsd_slam_viewer/src/IOWrapper/ROSPCOutputWrapper.h
+++ b/lsd_slam_viewer/src/IOWrapper/ROSPCOutputWrapper.h
@@ -42,10 +42,10 @@ class ROSPCOutputWrapper
 		virtual void publishPointCloudImage(cv::Mat* img_matrix);
 	//	virtual void publishDebugInfo(Eigen::Matrix<float, 20, 1> data);
 
-
+	 int width, height;
 
 	private:
-		int width, height;
+
 
     std::string pc_image_channel_name;
 		image_transport::Publisher pc_image_publisher;

--- a/lsd_slam_viewer/src/IOWrapper/ROSPCOutputWrapper.h
+++ b/lsd_slam_viewer/src/IOWrapper/ROSPCOutputWrapper.h
@@ -1,0 +1,55 @@
+/**
+* This file is part of LSD-SLAM.
+*
+* Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
+* For more information see <http://vision.in.tum.de/lsdslam>
+*
+* LSD-SLAM is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* LSD-SLAM is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with LSD-SLAM. If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#pragma once
+
+#include <ros/ros.h>
+
+//class image_transport;
+#include "image_transport/image_transport.h"
+
+#include <opencv2/highgui/highgui.hpp>
+//#include <opencv2/opencv.hpp>
+#include <cv_bridge/cv_bridge.h>
+
+
+/** Addition to LiveSLAMWrapper for ROS interoperability. */
+class ROSPCOutputWrapper
+{
+	public:
+
+		// initializes cam-calib independent stuff
+		ROSPCOutputWrapper(int width, int height);
+		~ROSPCOutputWrapper();
+
+		virtual void publishPointCloudImage(cv::Mat* img_matrix);
+	//	virtual void publishDebugInfo(Eigen::Matrix<float, 20, 1> data);
+
+
+
+	private:
+		int width, height;
+
+    std::string pc_image_channel_name;
+		image_transport::Publisher pc_image_publisher;
+		ros::NodeHandle nh_;
+
+    sensor_msgs::ImagePtr msg;
+};

--- a/lsd_slam_viewer/src/KeyFrameDisplay.cpp
+++ b/lsd_slam_viewer/src/KeyFrameDisplay.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -66,6 +66,7 @@ void KeyFrameDisplay::setFrom(lsd_slam_viewer::keyframeMsgConstPtr msg)
 {
 	// copy over campose.
 	memcpy(camToWorld.data(), msg->camToWorld.data(), 7*sizeof(float));
+
 
 	fx = msg->fx;
 	fy = msg->fy;
@@ -328,8 +329,11 @@ int KeyFrameDisplay::flushPC(std::ofstream* f)
 	for(int i=0;i<num;i++)
 	{
 		f->write((const char *)tmpBuffer[i].point,3*sizeof(float));
-		float color = tmpBuffer[i].color[0] / 255.0;
-		f->write((const char *)&color,sizeof(float));
+		//float color = tmpBuffer[i].color[0] / 255.0;
+		//f->write((const char *)&color,sizeof(float));
+		unsigned char color[4] = {tmpBuffer[i].color[2], tmpBuffer[i].color[1], tmpBuffer[i].color[0], 0};
+		f->write((const char *)color,4*sizeof(unsigned char));
+
 	}
 	//	*f << tmpBuffer[i].point[0] << " " << tmpBuffer[i].point[1] << " " << tmpBuffer[i].point[2] << " " << (tmpBuffer[i].color[0] / 255.0) << "\n";
 
@@ -338,6 +342,7 @@ int KeyFrameDisplay::flushPC(std::ofstream* f)
 	printf("Done flushing frame %d (%d points)!\n", this->id, num);
 	return num;
 }
+
 
 void KeyFrameDisplay::drawPC(float pointSize, float alpha)
 {
@@ -398,4 +403,3 @@ void KeyFrameDisplay::drawPC(float pointSize, float alpha)
 		glLightfv (GL_LIGHT0, GL_AMBIENT_AND_DIFFUSE, LightColor);
 	}
 }
-

--- a/lsd_slam_viewer/src/KeyFrameGraphDisplay.cpp
+++ b/lsd_slam_viewer/src/KeyFrameGraphDisplay.cpp
@@ -57,13 +57,19 @@ void KeyFrameGraphDisplay::publishPointCloudImage(GLubyte **pixels) {
 
     *pixels = (GLubyte*)realloc(*pixels, format_nchannels * sizeof(GLubyte) * width * height);
     glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, *pixels);
+		//GLenum error;
+
+		if (glGetError() != GL_NO_ERROR){
+			printf("Error while publishing. Skipping.\n");
+			return;
+		}
 
     cv::Mat temp_matrix(height,width, CV_8UC3, cv::Scalar(0,0,0));
     for (i = 0; i < height; i++) {
         for (j = 0; j < width; j++) {
             cur = format_nchannels * ((height - i - 1) * width + j);
-				    temp_matrix.at<cv::Vec3b>(i,j)[0] = (*pixels)[cur+2];
-				    temp_matrix.at<cv::Vec3b>(i,j)[1] = (*pixels)[cur+2];
+				    temp_matrix.at<cv::Vec3b>(i,j)[0] = (*pixels)[cur];
+				    temp_matrix.at<cv::Vec3b>(i,j)[1] = (*pixels)[cur+1];
 				    temp_matrix.at<cv::Vec3b>(i,j)[2] = (*pixels)[cur+2];
 
         }
@@ -71,8 +77,8 @@ void KeyFrameGraphDisplay::publishPointCloudImage(GLubyte **pixels) {
     }
 
 
-    //if (outputWrapper != nullptr)
-		//	 outputWrapper->publishPointCloudImage(&temp_matrix);
+    if (outputWrapper != nullptr)
+			 outputWrapper->publishPointCloudImage(&temp_matrix);
 }
 
 void KeyFrameGraphDisplay::setOutputWrapper(ROSPCOutputWrapper* outputWrapper){

--- a/lsd_slam_viewer/src/KeyFrameGraphDisplay.cpp
+++ b/lsd_slam_viewer/src/KeyFrameGraphDisplay.cpp
@@ -55,8 +55,8 @@ void KeyFrameGraphDisplay::publishPointCloudImage(GLubyte **pixels) {
     size_t i, j, k, cur;
     const size_t format_nchannels = 3;
 
-    *pixels = (GLubyte*)realloc(*pixels, format_nchannels * sizeof(GLubyte) * width * height);
-    glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, *pixels);
+    *pixels = (GLubyte*)realloc(*pixels, format_nchannels * sizeof(GLubyte) * frameWidth * frameHeight);
+    glReadPixels(0, 0, frameWidth, frameHeight, GL_RGB, GL_UNSIGNED_BYTE, *pixels);
 		//GLenum error;
 
 		if (glGetError() != GL_NO_ERROR){
@@ -64,25 +64,23 @@ void KeyFrameGraphDisplay::publishPointCloudImage(GLubyte **pixels) {
 			return;
 		}
 
-    cv::Mat temp_matrix(height,width, CV_8UC3, cv::Scalar(0,0,0));
-    for (i = 0; i < height; i++) {
-        for (j = 0; j < width; j++) {
-            cur = format_nchannels * ((height - i - 1) * width + j);
+    cv::Mat temp_matrix(frameHeight,frameWidth, CV_8UC3, cv::Scalar(0,0,0));
+    for (i = 0; i < frameHeight; i++) {
+        for (j = 0; j < frameWidth; j++) {
+            cur = format_nchannels * ((frameHeight - i - 1) * frameWidth + j);
 				    temp_matrix.at<cv::Vec3b>(i,j)[0] = (*pixels)[cur];
 				    temp_matrix.at<cv::Vec3b>(i,j)[1] = (*pixels)[cur+1];
 				    temp_matrix.at<cv::Vec3b>(i,j)[2] = (*pixels)[cur+2];
-
         }
-
     }
-
-
     if (outputWrapper != nullptr)
 			 outputWrapper->publishPointCloudImage(&temp_matrix);
 }
 
 void KeyFrameGraphDisplay::setOutputWrapper(ROSPCOutputWrapper* outputWrapper){
      this->outputWrapper = outputWrapper;
+		 this->frameWidth = this->outputWrapper->width;
+		 this->frameHeight = this->outputWrapper->height;
 }
 
 

--- a/lsd_slam_viewer/src/KeyFrameGraphDisplay.cpp
+++ b/lsd_slam_viewer/src/KeyFrameGraphDisplay.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -25,18 +25,58 @@
 #include <sstream>
 #include <fstream>
 
+// For debugging timing.
+#include <chrono>
+
 #include "ros/package.h"
+
+#include "IOWrapper/ROSPCOutputWrapper.h"
+
+#include <opencv2/opencv.hpp>
+
+using namespace std::chrono;
 
 KeyFrameGraphDisplay::KeyFrameGraphDisplay()
 {
 	flushPointcloud = false;
 	printNumbers = false;
+        // Initialize the outputWrapper
 }
 
 KeyFrameGraphDisplay::~KeyFrameGraphDisplay()
 {
 	for(unsigned int i=0;i<keyframes.size();i++)
 		delete keyframes[i];
+}
+
+
+
+void KeyFrameGraphDisplay::publishPointCloudImage(GLubyte **pixels) {
+    size_t i, j, k, cur;
+    const size_t format_nchannels = 3;
+
+    *pixels = (GLubyte*)realloc(*pixels, format_nchannels * sizeof(GLubyte) * width * height);
+    glReadPixels(0, 0, width, height, GL_RGB, GL_UNSIGNED_BYTE, *pixels);
+
+    cv::Mat temp_matrix(height,width, CV_8UC3, cv::Scalar(0,0,0));
+    for (i = 0; i < height; i++) {
+        for (j = 0; j < width; j++) {
+            cur = format_nchannels * ((height - i - 1) * width + j);
+				    temp_matrix.at<cv::Vec3b>(i,j)[0] = (*pixels)[cur+2];
+				    temp_matrix.at<cv::Vec3b>(i,j)[1] = (*pixels)[cur+2];
+				    temp_matrix.at<cv::Vec3b>(i,j)[2] = (*pixels)[cur+2];
+
+        }
+
+    }
+
+
+    //if (outputWrapper != nullptr)
+		//	 outputWrapper->publishPointCloudImage(&temp_matrix);
+}
+
+void KeyFrameGraphDisplay::setOutputWrapper(ROSPCOutputWrapper* outputWrapper){
+     this->outputWrapper = outputWrapper;
 }
 
 
@@ -55,7 +95,13 @@ void KeyFrameGraphDisplay::draw()
 		if((showKFPointclouds && (int)i > cutFirstNKf) || i == keyframes.size()-1)
 			keyframes[i]->drawPC(pointTesselation, 1);
 	}
+  if (publish_counter % publish_frequency == 0){
 
+      publishPointCloudImage(&pixels);
+      if (publish_counter > 300)
+         publish_counter = 0;
+  }
+  publish_counter ++;
 
 	if(flushPointcloud)
 	{
@@ -71,15 +117,18 @@ void KeyFrameGraphDisplay::draw()
 		f.flush();
 		f.close();
 
-		std::ofstream f2((ros::package::getPath("lsd_slam_viewer")+"/pc.ply").c_str());
-		f2 << std::string("ply\n");
-		f2 << std::string("format binary_little_endian 1.0\n");
-		f2 << std::string("element vertex ") << numpts << std::string("\n");
-		f2 << std::string("property float x\n");
-		f2 << std::string("property float y\n");
-		f2 << std::string("property float z\n");
-		f2 << std::string("property float intensity\n");
-		f2 << std::string("end_header\n");
+		std::ofstream f2((ros::package::getPath("lsd_slam_viewer")+"/pc.pcd").c_str());
+		f2 << std::string("# .PCD v0.7 - Point Cloud Data file format\n");
+		f2 << std::string("VERSION 0.7\n");
+		f2 << std::string("FIELDS x y z rgb\n");
+		f2 << std::string("SIZE 4 4 4 4\n");
+		f2 << std::string("TYPE F F F F\n");
+		f2 << std::string("COUNT 1 1 1 1\n");
+		f2 << std::string("WIDTH ") << numpts << std::string("\n");
+		f2 << std::string("HEIGHT 1\n");
+		f2 << std::string("VIEWPOINT 0 0 0 1 0 0 0\n");
+		f2 << std::string("POINTS ") << numpts << std::string("\n");
+		f2 << std::string("DATA binary\n");
 
 		std::ifstream f3((ros::package::getPath("lsd_slam_viewer")+"/pc_tmp.ply").c_str());
 		while(!f3.eof()) f2.put(f3.get());

--- a/lsd_slam_viewer/src/KeyFrameGraphDisplay.cpp
+++ b/lsd_slam_viewer/src/KeyFrameGraphDisplay.cpp
@@ -101,13 +101,15 @@ void KeyFrameGraphDisplay::draw()
 		if((showKFPointclouds && (int)i > cutFirstNKf) || i == keyframes.size()-1)
 			keyframes[i]->drawPC(pointTesselation, 1);
 	}
-  if (publish_counter % publish_frequency == 0){
-
-      publishPointCloudImage(&pixels);
-      if (publish_counter > 300)
-         publish_counter = 0;
-  }
-  publish_counter ++;
+	// Output the pointcloud publisher.
+	if (outputPointCloudPublisher){
+	  if (publish_counter % publish_frequency == 0){
+	      publishPointCloudImage(&pixels);
+	      if (publish_counter > 300)
+	         publish_counter = 0;
+	  }
+	  publish_counter ++;
+	}
 
 	if(flushPointcloud)
 	{

--- a/lsd_slam_viewer/src/KeyFrameGraphDisplay.h
+++ b/lsd_slam_viewer/src/KeyFrameGraphDisplay.h
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -28,7 +28,14 @@
 #include "lsd_slam_viewer/keyframeMsg.h"
 #include "boost/thread.hpp"
 
+#include <GL/gl.h>
+//#include <GL/glu.h>
+#include <GL/glut.h>
+//#include <GL/glext.h>
+
 class KeyFrameDisplay;
+class ROSPCOutputWrapper;
+//#include "IOWrapper/OutputWrapper.h"
 
 
 struct GraphConstraint
@@ -63,16 +70,32 @@ public:
 	void addMsg(lsd_slam_viewer::keyframeMsgConstPtr msg);
 	void addGraphMsg(lsd_slam_viewer::keyframeGraphMsgConstPtr msg);
 
+  // For Publishing Image Messages
+  void setOutputWrapper(ROSPCOutputWrapper* outputWrapper);
+
+
 
 
 	bool flushPointcloud;
 	bool printNumbers;
 private:
+        ROSPCOutputWrapper* outputWrapper;
+
 	std::map<int, KeyFrameDisplay*> keyframesByID;
 	std::vector<KeyFrameDisplay*> keyframes;
 	std::vector<GraphConstraintPt> constraints;
 
 	boost::mutex dataMutex;
+
+	// Both of these should be static
+	GLubyte *pixels = NULL;
+  void publishPointCloudImage(GLubyte **pixels);
+
+	// Pointcloud output variables.
+  int publish_frequency = 5;
+  int publish_counter = 0;
+  unsigned int width = 800;
+	unsigned int height = 450;
 
 };
 

--- a/lsd_slam_viewer/src/KeyFrameGraphDisplay.h
+++ b/lsd_slam_viewer/src/KeyFrameGraphDisplay.h
@@ -94,8 +94,8 @@ private:
 	// Pointcloud output variables.
   int publish_frequency = 5;
   int publish_counter = 0;
-  unsigned int width = 800;
-	unsigned int height = 450;
+  unsigned int frameWidth = 800;
+	unsigned int frameHeight = 450;
 
 };
 

--- a/lsd_slam_viewer/src/PointCloudViewer.cpp
+++ b/lsd_slam_viewer/src/PointCloudViewer.cpp
@@ -112,6 +112,9 @@ void PointCloudViewer::reset()
 
 	resetRequested=false;
 
+	liveCameraTracking=false;
+	outputPointCloudPublisher=false;
+
 	save_folder = ros::package::getPath("lsd_slam_viewer")+"/save/";
 	localMsBetweenSaves = 1;
 	simMsBetweenSaves = 1;
@@ -131,8 +134,8 @@ void PointCloudViewer::reset()
 	lastAutoplayCheckedSaveTime = -1;
 
 	animationPlaybackEnabled = false;
-  printf("PointCloudViewer.cpp. Setting custom window size\n");
- 	this->setFixedSize(800,450);
+
+	setToVideoSize();
 
 }
 
@@ -188,7 +191,6 @@ void PointCloudViewer::draw()
 		reset();
 		resetRequested = false;
 	}
-
 
 	glPushMatrix();
 
@@ -307,8 +309,7 @@ void PointCloudViewer::keyReleaseEvent(QKeyEvent *e)
 
 void PointCloudViewer::setToVideoSize()
 {
-	//this->setFixedSize(1600,900);
-        this->setFixedSize(800,450);
+   this->setFixedSize(frameWidth,frameHeight);
 }
 
 

--- a/lsd_slam_viewer/src/PointCloudViewer.cpp
+++ b/lsd_slam_viewer/src/PointCloudViewer.cpp
@@ -131,7 +131,7 @@ void PointCloudViewer::reset()
 	lastAutoplayCheckedSaveTime = -1;
 
 	animationPlaybackEnabled = false;
-    printf("PointCloudViewer.cpp. Setting custom window size\n");
+  printf("PointCloudViewer.cpp. Setting custom window size\n");
  	this->setFixedSize(800,450);
 
 }
@@ -247,7 +247,7 @@ void PointCloudViewer::draw()
 		}
 	}
 
-  if (followCurrentFrameAnimation){
+  if (liveCameraTracking){
       // Get a reference to a qglviewer.
       qglviewer::Frame frame;
       frame = qglviewer::Frame();
@@ -369,11 +369,11 @@ void PointCloudViewer::keyPressEvent(QKeyEvent *e)
 
     	  break;
      case Qt::Key_M:
-	  if(followCurrentFrameAnimation)
-    		  printf("DISABLE follow current frame animation!\n)");
-    	  else
-    		  printf("ENABLE follow current frame animation!\n");
-          followCurrentFrameAnimation = !followCurrentFrameAnimation;
+				if(liveCameraTracking)
+				  printf("DISABLE live camera tracking animation!\n)");
+				else
+				  printf("ENABLE live camera tracking animation!\n");
+        liveCameraTracking = !liveCameraTracking;
 
 	  break;
 

--- a/lsd_slam_viewer/src/PointCloudViewer.cpp
+++ b/lsd_slam_viewer/src/PointCloudViewer.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -42,6 +42,11 @@
 #include <iostream>
 #include <fstream>
 
+#include "IOWrapper/ROSPCOutputWrapper.h"
+
+
+
+
 PointCloudViewer::PointCloudViewer()
 {
 	setPathKey(Qt::Key_0,0);
@@ -54,6 +59,7 @@ PointCloudViewer::PointCloudViewer()
 	setPathKey(Qt::Key_7,7);
 	setPathKey(Qt::Key_8,8);
 	setPathKey(Qt::Key_9,9);
+
 
 
 	currentCamDisplay = 0;
@@ -79,6 +85,15 @@ PointCloudViewer::~PointCloudViewer()
 {
 	delete currentCamDisplay;
 	delete graphDisplay;
+}
+void PointCloudViewer::setOutputWrapper(ROSPCOutputWrapper* outputWrapper){
+     if (graphDisplay != 0){
+         graphDisplay->setOutputWrapper(outputWrapper);
+         printf("PointCloudViewer::setOutputWrapper(). Successfuly set output wrapper.");
+     }
+     else{
+         printf("PointCloudViewer::setOutputWrapper(). Error. No KeyFrameGraph!");
+     }
 }
 
 
@@ -116,6 +131,9 @@ void PointCloudViewer::reset()
 	lastAutoplayCheckedSaveTime = -1;
 
 	animationPlaybackEnabled = false;
+    printf("PointCloudViewer.cpp. Setting custom window size\n");
+ 	this->setFixedSize(800,450);
+
 }
 
 void PointCloudViewer::addFrameMsg(lsd_slam_viewer::keyframeMsgConstPtr msg)
@@ -229,6 +247,20 @@ void PointCloudViewer::draw()
 		}
 	}
 
+  if (followCurrentFrameAnimation){
+      // Get a reference to a qglviewer.
+      qglviewer::Frame frame;
+      frame = qglviewer::Frame();
+      camera()->frame()->setOrientation(currentCamDisplay->camToWorld.quaternion().normalized().w(),
+                                        currentCamDisplay->camToWorld.quaternion().normalized().x(),
+                                        currentCamDisplay->camToWorld.quaternion().normalized().y(),
+                                        currentCamDisplay->camToWorld.quaternion().normalized().z());
+      camera()->frame()->setPosition(currentCamDisplay->camToWorld.translation()[0],
+                                     currentCamDisplay->camToWorld.translation()[1],
+                                     currentCamDisplay->camToWorld.translation()[2]);
+
+
+     }
 
 
 	if(showCurrentCamera)
@@ -275,7 +307,8 @@ void PointCloudViewer::keyReleaseEvent(QKeyEvent *e)
 
 void PointCloudViewer::setToVideoSize()
 {
-	this->setFixedSize(1600,900);
+	//this->setFixedSize(1600,900);
+        this->setFixedSize(800,450);
 }
 
 
@@ -335,6 +368,15 @@ void PointCloudViewer::keyPressEvent(QKeyEvent *e)
     	  remakeAnimation();
 
     	  break;
+     case Qt::Key_M:
+	  if(followCurrentFrameAnimation)
+    		  printf("DISABLE follow current frame animation!\n)");
+    	  else
+    		  printf("ENABLE follow current frame animation!\n");
+          followCurrentFrameAnimation = !followCurrentFrameAnimation;
+
+	  break;
+
 
       case Qt::Key_I :	// reset animation list
 			meddleMutex.lock();
@@ -401,6 +443,7 @@ void PointCloudViewer::keyPressEvent(QKeyEvent *e)
     	  customAnimationEnabled = !customAnimationEnabled;
     	  break;
 
+
       case Qt::Key_O:
     	  if(animationPlaybackEnabled)
     	  {
@@ -427,4 +470,3 @@ void PointCloudViewer::keyPressEvent(QKeyEvent *e)
     	  break;
     }
   }
-

--- a/lsd_slam_viewer/src/PointCloudViewer.h
+++ b/lsd_slam_viewer/src/PointCloudViewer.h
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -27,8 +27,10 @@
 #include <vector>
 #include "boost/thread.hpp"
 #include "qevent.h"
+// Messages
 #include "lsd_slam_viewer/keyframeMsg.h"
 #include "lsd_slam_viewer/keyframeGraphMsg.h"
+#include "geometry_msgs/PoseStamped.h"
 
 #include "QGLViewer/keyFrameInterpolator.h"
 
@@ -37,6 +39,8 @@ class QApplication;
 class KeyFrameGraphDisplay;
 class CameraDisplay;
 class KeyFrameDisplay;
+
+class ROSPCOutputWrapper;
 
 #include "settings.h"
 
@@ -153,12 +157,15 @@ class PointCloudViewer : public QGLViewer
 public:
 	PointCloudViewer();
 	~PointCloudViewer();
-
+  // For publishing image messages.
+  void setOutputWrapper(ROSPCOutputWrapper* outputWrapper);
 
 	void reset();
 
 	void addFrameMsg(lsd_slam_viewer::keyframeMsgConstPtr msg);
 	void addGraphMsg(lsd_slam_viewer::keyframeGraphMsgConstPtr msg);
+
+
 
 
 protected :
@@ -223,6 +230,8 @@ private:
 
 
 	void remakeAnimation();
+
+  bool followCurrentFrameAnimation = false;
+
+
 };
-
-

--- a/lsd_slam_viewer/src/PointCloudViewer.h
+++ b/lsd_slam_viewer/src/PointCloudViewer.h
@@ -165,6 +165,9 @@ public:
 	void addFrameMsg(lsd_slam_viewer::keyframeMsgConstPtr msg);
 	void addGraphMsg(lsd_slam_viewer::keyframeGraphMsgConstPtr msg);
 
+	int frameWidth = 800;
+	int frameHeight = 450;
+
 
 
 

--- a/lsd_slam_viewer/src/main_viewer.cpp
+++ b/lsd_slam_viewer/src/main_viewer.cpp
@@ -70,6 +70,8 @@ void dynConfCb(lsd_slam_viewer::LSDSLAMViewerParamsConfig &config, uint32_t leve
 	cutFirstNKf = config.cutFirstNKf;
 
 	saveAllVideo = config.saveAllVideo;
+	liveCameraTracking = config.liveCameraTracking;
+	outputPointCloudPublisher = config.outputPointCloudPublisher;
 
 }
 
@@ -136,7 +138,7 @@ void rosThreadLoop( int argc, char** argv )
 	ros::Subscriber graph_sub       = nh.subscribe(nh.resolveName("lsd_slam/graph"),10, graphCb);
     //ros::Subscriber pose_sub = nh.subscribe(nh.resolveName("lsd_slam/pose"),1, poseCb);
 
-
+	ROS_INFO("Done setting up subscribers.");
 	ros::spin();
 
 	ros::shutdown();

--- a/lsd_slam_viewer/src/main_viewer.cpp
+++ b/lsd_slam_viewer/src/main_viewer.cpp
@@ -121,7 +121,7 @@ void rosThreadLoop( int argc, char** argv )
 	// Setup the publisher
 	ROS_INFO("Initialized Pointcloud Publisher");
 	// Set the output wrapper.
-	outputWrapper = new ROSPCOutputWrapper(800, 450);
+	outputWrapper = new ROSPCOutputWrapper(viewer->frameWidth, viewer->frameHeight);
 	setOutputWrapper(outputWrapper);
 
 

--- a/lsd_slam_viewer/src/main_viewer.cpp
+++ b/lsd_slam_viewer/src/main_viewer.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -42,6 +42,13 @@
 PointCloudViewer* viewer = 0;
 
 
+#include "IOWrapper/ROSPCOutputWrapper.h"
+#include "geometry_msgs/PoseStamped.h"
+//ros::NodeHandle nh_;
+//ros::Publisher pc_image_publisher;
+//image_transport::Publisher pc_image_publisher;
+
+
 void dynConfCb(lsd_slam_viewer::LSDSLAMViewerParamsConfig &config, uint32_t level)
 {
 
@@ -79,27 +86,56 @@ void graphCb(lsd_slam_viewer::keyframeGraphMsgConstPtr msg)
 	if(viewer != 0)
 		viewer->addGraphMsg(msg);
 }
+/*
+ The pose might be useful at a late time?
+ */
+void poseCb(const geometry_msgs::PoseStamped& msg){
+    //if (viewer != 0)
+    //    viewer->setCurrentPose(msg);
+}
+void setOutputWrapper(ROSPCOutputWrapper* outputWrapper){
+       if (viewer != 0){
+           if (outputWrapper != nullptr)
+                 viewer->setOutputWrapper(outputWrapper);
+           else
+                 printf("Error. Output wrapper is null");
+       }
+
+}
+
 
 
 
 void rosThreadLoop( int argc, char** argv )
 {
+	ROSPCOutputWrapper* outputWrapper = nullptr;
 	printf("Started ROS thread\n");
 
 	//glutInit(&argc, argv);
 
 	ros::init(argc, argv, "viewer");
+	ros::NodeHandle nh;
 	ROS_INFO("lsd_slam_viewer started");
+	// Setup the publisher
+	ROS_INFO("Initialized Pointcloud Publisher");
+	// Set the output wrapper.
+	outputWrapper = new ROSPCOutputWrapper(800, 450);
+	setOutputWrapper(outputWrapper);
+
+
+
 
 	dynamic_reconfigure::Server<lsd_slam_viewer::LSDSLAMViewerParamsConfig> srv;
 	srv.setCallback(dynConfCb);
 
 
-	ros::NodeHandle nh;
+
 
 	ros::Subscriber liveFrames_sub = nh.subscribe(nh.resolveName("lsd_slam/liveframes"),1, frameCb);
 	ros::Subscriber keyFrames_sub = nh.subscribe(nh.resolveName("lsd_slam/keyframes"),20, frameCb);
 	ros::Subscriber graph_sub       = nh.subscribe(nh.resolveName("lsd_slam/graph"),10, graphCb);
+    //ros::Subscriber pose_sub = nh.subscribe(nh.resolveName("lsd_slam/pose"),1, poseCb);
+
 
 	ros::spin();
 
@@ -159,6 +195,8 @@ int main( int argc, char** argv )
 
 	// Instantiate the viewer.
 	viewer = new PointCloudViewer();
+
+
 
 
 	#if QT_VERSION < 0x040000

--- a/lsd_slam_viewer/src/settings.cpp
+++ b/lsd_slam_viewer/src/settings.cpp
@@ -27,11 +27,11 @@ float pointTesselation = 1;
 float lineTesselation = 2;
 
 bool keepInMemory=true;
-bool showKFCameras = true;
-bool showKFPointclouds = true;
-bool showConstraints = true;
-bool showCurrentCamera = true;
-bool showCurrentPointcloud = true;
+bool showKFCameras = false;
+bool showKFPointclouds = false;
+bool showConstraints = false;
+bool showCurrentCamera = false;
+bool showCurrentPointcloud = false;
 
 float scaledDepthVarTH = 1;
 float absDepthVarTH = 1;

--- a/lsd_slam_viewer/src/settings.cpp
+++ b/lsd_slam_viewer/src/settings.cpp
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -40,6 +40,9 @@ int cutFirstNKf = 5;
 int sparsifyFactor = 1;
 
 bool saveAllVideo = false;
+
+bool liveCameraTracking = false;
+bool outputPointCloudPublisher = false;
 
 int numRefreshedAlready = 0;
 

--- a/lsd_slam_viewer/src/settings.h
+++ b/lsd_slam_viewer/src/settings.h
@@ -2,7 +2,7 @@
 * This file is part of LSD-SLAM.
 *
 * Copyright 2013 Jakob Engel <engelj at in dot tum dot de> (Technical University of Munich)
-* For more information see <http://vision.in.tum.de/lsdslam> 
+* For more information see <http://vision.in.tum.de/lsdslam>
 *
 * LSD-SLAM is free software: you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
@@ -37,6 +37,9 @@ extern int minNearSupport;
 extern int cutFirstNKf;
 extern int sparsifyFactor;
 extern bool saveAllVideo;
+
+extern bool liveCameraTracking;
+extern bool outputPointCloudPublisher;
 
 extern int numRefreshedAlready;
 


### PR DESCRIPTION
I've added the changes from [alexanderkoumis](https://github.com/alexanderkoumis/lsd_slam) repository for RGB pointcloud visualization.

Also, I've added a nifty feature to toggle Live Camera Tracking on the pointcloud viewer using either dynamic reconfigure or by hitting the `m` key. For a visualization of this, please see this [Wiki](https://github.com/omarabid59/lsd_slam/wiki/New-Features).

Finally, I've added the ability to output the rendered pointcloud display as a topic. This is set to disabled by default. To enable, see `lsd_slam_viewer/src/settings.cpp or using dynamic reconfigure.

